### PR TITLE
Add trusted publisher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      TWINE_USERNAME: ${{ secrets.PYPI_USER }}
-      TWINE_PASSWORD: ${{ secrets.PYPI_PASS }}
-
     steps:
     - uses: actions/checkout@v4
 
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.13"
         architecture: x64
 
     - name: Install dependencies
@@ -67,9 +63,48 @@ jobs:
     - name: List assets
       run: ls ./wheelhouse/ -al
 
-    - name: Upload wheels
-      if: github.event_name == 'workflow_dispatch'
-      run: |
-        pip install twine
-        echo "Publish to PyPI..."
-        twine upload --verbose wheelhouse/*
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write  # Required for Trusted Publishing
+    needs: get-versions
+    if: github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Download assets from GitHub release
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: ${{ github.repository }}
+          # download the latest release
+          latest: true
+          # don't download pre-releases
+          preRelease: false
+          fileName: "*"
+          # don't download GitHub-generated source tar and zip files
+          tarBall: false
+          zipBall: false
+          # create a directory to store the downloaded assets
+          out-file-path: assets-to-publish
+          # don't extract downloaded files
+          extract: false
+
+      - name: List downloaded assets
+        run: ls -la assets-to-publish
+      
+      - name: Upload assets to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # To test, use the TestPyPI:
+          repository-url: https://test.pypi.org/legacy/
+          # You must also create an account and project on TestPyPI,
+          # as well as set the trusted-publisher in the project settings:
+          # https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+          # To publish to the official PyPI repository, just keep
+          # repository-url commented out.
+          packages-dir: assets-to-publish
+          skip-existing: true
+          print-hash: true
+          verbose: true
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         # To test, use the TestPyPI:
-        repository-url: https://test.pypi.org/legacy/
+        # repository-url: https://test.pypi.org/legacy/
         # You must also create an account and project on TestPyPI,
         # as well as set the trusted-publisher in the project settings:
         # https://docs.pypi.org/trusted-publishers/adding-a-publisher/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,4 +107,3 @@ jobs:
           skip-existing: true
           print-hash: true
           verbose: true
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,8 @@ jobs:
     name: "Upload latest nlohmann-json version to PyPI"
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      id-token: write  # Required for Trusted Publishing
     steps:
     - uses: actions/checkout@v4
 
@@ -63,47 +64,17 @@ jobs:
     - name: List assets
       run: ls ./wheelhouse/ -al
 
-  publish:
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write  # Required for Trusted Publishing
-    needs: get-versions
-    if: github.event_name == 'workflow_dispatch'
-
-    steps:
-      - name: Download assets from GitHub release
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: ${{ github.repository }}
-          # download the latest release
-          latest: true
-          # don't download pre-releases
-          preRelease: false
-          fileName: "*"
-          # don't download GitHub-generated source tar and zip files
-          tarBall: false
-          zipBall: false
-          # create a directory to store the downloaded assets
-          out-file-path: assets-to-publish
-          # don't extract downloaded files
-          extract: false
-
-      - name: List downloaded assets
-        run: ls -la assets-to-publish
-      
-      - name: Upload assets to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # To test, use the TestPyPI:
-          repository-url: https://test.pypi.org/legacy/
-          # You must also create an account and project on TestPyPI,
-          # as well as set the trusted-publisher in the project settings:
-          # https://docs.pypi.org/trusted-publishers/adding-a-publisher/
-          # To publish to the official PyPI repository, just keep
-          # repository-url commented out.
-          packages-dir: assets-to-publish
-          skip-existing: true
-          print-hash: true
-          verbose: true
+    - name: Upload assets to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        # To test, use the TestPyPI:
+        repository-url: https://test.pypi.org/legacy/
+        # You must also create an account and project on TestPyPI,
+        # as well as set the trusted-publisher in the project settings:
+        # https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+        # To publish to the official PyPI repository, just keep
+        # repository-url commented out.
+        packages-dir: wheelhouse
+        skip-existing: true
+        print-hash: true
+        verbose: true


### PR DESCRIPTION
Adds trusted publisher as the method to publish the package to PyPI.

- [x] Manual CI run to trigger the action. https://github.com/PowerGridModel/nlohmann-json-pypi/actions/runs/14757140644/job/41428208059
- [x] Publish package in Test PyPI. https://test.pypi.org/project/nlohmann-json/#history
